### PR TITLE
fix: remove explicit nil from optional properties

### DIFF
--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -82,7 +82,7 @@ class BaseTerminalController: NSWindowController,
 
     /// A managed tab/window title that takes precedence over user-initiated overrides.
     /// Used for features that pin the title to a specific concept (e.g. worktree tabs).
-    var managedTitleOverride: String? = nil {
+    var managedTitleOverride: String? {
         didSet { applyTitleToWindow() }
     }
 

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -8,7 +8,7 @@ final class WorktrunkSidebarState: ObservableObject {
     @Published var columnVisibility: NavigationSplitViewVisibility
     @Published var expandedRepoIDs: Set<UUID> = []
     @Published var expandedWorktreePaths: Set<String> = []
-    @Published var selection: SidebarSelection? = nil
+    @Published var selection: SidebarSelection?
     @Published var isApplyingRemoteUpdate: Bool = false
 
     init(
@@ -211,12 +211,12 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
     private var worktrunkSidebarSyncCancellables: Set<AnyCancellable> = []
     private var worktrunkSidebarSyncApplyingRemoteUpdate: Bool = false
     private let gitDiffSidebarState = GitDiffSidebarState()
-    private var lastTabSwitchRefreshAt: Date? = nil
+    private var lastTabSwitchRefreshAt: Date?
     private let tabSwitchRefreshThrottle: TimeInterval = 0.15
-    private var pendingTabSwitchRefresh: DispatchWorkItem? = nil
-    private var lastTabSwitchSurfaceID: UUID? = nil
+    private var pendingTabSwitchRefresh: DispatchWorkItem?
+    private var lastTabSwitchSurfaceID: UUID?
 
-    private(set) var worktreeTabRootPath: String? = nil {
+    private(set) var worktreeTabRootPath: String? {
         didSet { syncWorktreeTabTitle() }
     }
 


### PR DESCRIPTION
Fix SwiftLint implicit_optional_initialization violations by removing explicit `= nil` initializers from optional property declarations. Optional properties in Swift implicitly initialize to nil and should not be explicitly assigned this value.

Changes made across BaseTerminalController and TerminalController to comply with SwiftLint rules.