### PR TITLE
Add mechanical safeguards for PR target repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,3 +52,7 @@ A file for [guiding coding agents](https://agents.md/).
 - Never create an issue.
 - NEVER EVER EVER EVER EVER EVER open a PR against `ghostty-org/ghostty` (upstream), under any circumstances.
 - If a PR is explicitly requested, it must target `sidequery/ghostree` only, never upstream.
+- Before creating any PR, verify: `gh repo set-default --view` must show `sidequery/ghostree`.
+  If it does not, run `gh repo set-default sidequery/ghostree` first.
+- Always use `--repo sidequery/ghostree` flag with `gh pr create` as a safeguard.
+- NEVER use `--repo ghostty-org/ghostty` or any upstream reference in `gh pr` commands.


### PR DESCRIPTION
## Summary
- Adds explicit `gh` CLI verification steps and `--repo` flag requirements to AGENTS.md
- Prevents agents from accidentally opening PRs against upstream (ghostty-org/ghostty) instead of sidequery/ghostree
- Complements the existing text-based instructions with mechanical safeguards that agents must follow before running `gh pr create`