### PR TITLE
Add "Display session time" setting to Worktrunk

### DIFF
--- a/macos/Sources/Features/Worktrunk/WorktrunkPreferences.swift
+++ b/macos/Sources/Features/Worktrunk/WorktrunkPreferences.swift
@@ -274,6 +274,7 @@ enum WorktrunkPreferences {
     static let defaultAgentKey = "GhosttyWorktrunkDefaultAgent.v1"
     static let githubIntegrationKey = "GhostreeGitHubIntegration.v1"
     static let lastEditorKey = "GhostreeLastEditor.v1"
+    static let displaySessionTimeKey = "GhostreeDisplaySessionTime.v1"
 
     static var worktreeTabsEnabled: Bool {
         UserDefaults.standard.bool(forKey: worktreeTabsKey)
@@ -310,5 +311,12 @@ enum WorktrunkPreferences {
             return last
         }
         return installed.first
+    }
+
+    static var displaySessionTimeEnabled: Bool {
+        if !UserDefaults.standard.dictionaryRepresentation().keys.contains(displaySessionTimeKey) {
+            return true
+        }
+        return UserDefaults.standard.bool(forKey: displaySessionTimeKey)
     }
 }

--- a/macos/Sources/Features/Worktrunk/WorktrunkSettingsView.swift
+++ b/macos/Sources/Features/Worktrunk/WorktrunkSettingsView.swift
@@ -6,6 +6,7 @@ struct WorktrunkSettingsView: View {
     @AppStorage(WorktrunkPreferences.openBehaviorKey) private var openBehaviorRaw: String = WorktrunkOpenBehavior.newTab.rawValue
     @AppStorage(WorktrunkPreferences.defaultAgentKey) private var defaultActionRaw: String = WorktrunkDefaultAction.terminal.rawValue
     @AppStorage(WorktrunkPreferences.githubIntegrationKey) private var githubIntegrationEnabled: Bool = true
+    @AppStorage(WorktrunkPreferences.displaySessionTimeKey) private var displaySessionTimeEnabled: Bool = true
 
     @State private var ghAvailable: Bool = false
 
@@ -78,6 +79,13 @@ struct WorktrunkSettingsView: View {
                             .font(.caption)
                     }
                 }
+            }
+
+            Section("Display") {
+                Toggle("Display session time", isOn: $displaySessionTimeEnabled)
+                Text("Show relative timestamps next to worktrees and sessions in the sidebar.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
         }
         .formStyle(.grouped)

--- a/macos/Sources/Features/Worktrunk/WorktrunkSidebarView.swift
+++ b/macos/Sources/Features/Worktrunk/WorktrunkSidebarView.swift
@@ -17,6 +17,7 @@ struct WorktrunkSidebarView: View {
 
     @AppStorage(WorktrunkPreferences.defaultAgentKey) private var defaultActionRaw: String = WorktrunkDefaultAction.terminal.rawValue
     @AppStorage(WorktrunkPreferences.sidebarTabsKey) private var sidebarTabsEnabled: Bool = true
+    @AppStorage(WorktrunkPreferences.displaySessionTimeKey) private var displaySessionTimeEnabled: Bool = true
     @State private var createSheetRepo: WorktrunkStore.Repository?
     @State private var removeRepoConfirm: WorktrunkStore.Repository?
     @State private var removeWorktreeConfirm: WorktrunkStore.Worktree?
@@ -675,7 +676,7 @@ struct WorktrunkSidebarView: View {
                 VStack(alignment: .leading, spacing: 1) {
                     Text(wt.branch)
                         .lineLimit(1)
-                    if let recencyDate {
+                    if displaySessionTimeEnabled, let recencyDate {
                         (Text(repoName) + Text(" • ") + Text(recencyDate, style: .relative))
                             .font(.caption)
                             .foregroundStyle(.secondary)
@@ -947,6 +948,7 @@ private struct WorktreeTabRowLabel: View {
     let onDropBefore: (Int) -> Void
     let windowNumberByWorktreePath: [String: Int]
 
+    @AppStorage(WorktrunkPreferences.displaySessionTimeKey) private var displaySessionTimeEnabled: Bool = true
     @State private var isDropTarget: Bool = false
 
     private var isDropTargetBinding: Binding<Bool> {
@@ -977,7 +979,7 @@ private struct WorktreeTabRowLabel: View {
                             .fontWeight(tab.isActive ? .semibold : .regular)
                         if let repoName {
                             let recencyDate = store.recencyDate(for: worktree.path)
-                            if let recencyDate {
+                            if displaySessionTimeEnabled, let recencyDate {
                                 (Text(repoName) + Text(" • ") + Text(recencyDate, style: .relative))
                                     .font(.caption)
                                     .foregroundStyle(.secondary)
@@ -1100,7 +1102,7 @@ private struct CreateWorktreeSheet: View {
     @State private var base: String = ""
     @State private var createBranch: Bool = true
     @State private var isWorking: Bool = false
-    @State private var errorText: String? = nil
+    @State private var errorText: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -1170,6 +1172,8 @@ private struct SessionRow: View {
     let session: AISession
     let onResume: () -> Void
 
+    @AppStorage(WorktrunkPreferences.displaySessionTimeKey) private var displaySessionTimeEnabled: Bool = true
+
     var body: some View {
         Button(action: onResume) {
             HStack {
@@ -1186,11 +1190,13 @@ private struct SessionRow: View {
                                 .font(.caption2)
                                 .foregroundStyle(.secondary)
                         }
-                        Text("•")
-                            .foregroundStyle(.secondary)
-                        Text(session.timestamp, style: .relative)
-                            .font(.caption2)
-                            .foregroundStyle(.secondary)
+                        if displaySessionTimeEnabled {
+                            Text("•")
+                                .foregroundStyle(.secondary)
+                            Text(session.timestamp, style: .relative)
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
                     }
                 }
                 Spacer()


### PR DESCRIPTION
## Summary
- Adds a new **"Display session time"** toggle in Worktrunk settings (under a new "Display" section at the end)
- Enabled by default, preserving current behavior
- When disabled, hides the continuously-updating relative timestamps ("X ago") next to worktrees and sessions in the sidebar, reducing visual distraction while keeping the counters tracked internally

I'm adding this because the constantly-updating relative timestamps end up being very distracting to my workflow — they pull my attention away from the actual task at hand.

## Test plan
- [x] `zig build` succeeds
- [x] `zig build test` passes
- [x] `zig build run` launches the app successfully
- [x] Toggle on: verify relative timestamps appear next to worktrees and sessions
- [x] Toggle off: verify timestamps disappear, repo names and session info still show
- [x] Restart app: verify preference persists