### PR TITLE
macos: make diff sidebar button a visual toggle

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -1850,13 +1850,19 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
             )
             if let window = window as? TerminalWindow {
                 window.titlebarFont = lastTitlebarFont
+                window.setDiffSidebarButtonState(willShow)
             }
         }
     }
 
     @objc func closeGitDiff(_ sender: Any?) {
         guard #available(macOS 26.0, *) else { return }
-        Task { await gitDiffSidebarState.setVisible(false, cwd: nil) }
+        Task {
+            await gitDiffSidebarState.setVisible(false, cwd: nil)
+            if let window = window as? TerminalWindow {
+                window.setDiffSidebarButtonState(false)
+            }
+        }
     }
 
     @objc func openInEditor(_ sender: Any?) {

--- a/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
@@ -38,11 +38,11 @@ class TerminalWindow: NSWindow {
     private(set) var derivedConfig: DerivedConfig = .init()
 
     /// Sets up our tab context menu
-    private var tabMenuObserver: NSObjectProtocol? = nil
-    private var titlebarFontTabGroupObservation: NSKeyValueObservation? = nil
-    private var titlebarFontTabBarObservation: NSKeyValueObservation? = nil
-    private var lastTitlebarFontState: TitlebarFontState? = nil
-    private var lastAppliedAppearance: AppearanceState? = nil
+    private var tabMenuObserver: NSObjectProtocol?
+    private var titlebarFontTabGroupObservation: NSKeyValueObservation?
+    private var titlebarFontTabBarObservation: NSKeyValueObservation?
+    private var lastTitlebarFontState: TitlebarFontState?
+    private var lastAppliedAppearance: AppearanceState?
 
     /// Whether this window supports the update accessory. If this is false, then views within this
     /// window should determine how to show update notifications.
@@ -178,7 +178,7 @@ class TerminalWindow: NSWindow {
             button.controlSize = .large
             button.target = terminalController
             button.action = #selector(TerminalController.toggleGitDiffSidebar(_:))
-            button.setButtonType(.momentaryPushIn)
+            button.setButtonType(.pushOnPushOff)
 
             container.addSubview(button)
             NSLayoutConstraint.activate([
@@ -451,6 +451,13 @@ class TerminalWindow: NSWindow {
         label.postsFrameChangedNotifications = true
         return label
     }()
+
+    // MARK: Diff Sidebar Toggle
+
+    /// Update the diff sidebar toggle button to reflect visibility state.
+    func setDiffSidebarButtonState(_ isOn: Bool) {
+        diffSidebarButton?.state = isOn ? .on : .off
+    }
 
     // MARK: Surface Zoom
 


### PR DESCRIPTION
## Summary
- Changes the diff sidebar titlebar button (plusminus icon) from `momentaryPushIn` to `pushOnPushOff` so it visually reflects whether the diff sidebar is open
- Adds `setDiffSidebarButtonState(_:)` to `TerminalWindow` and calls it from `toggleGitDiffSidebar` and `closeGitDiff` in `TerminalController`
- The button now appears selected/highlighted when the diff sidebar is visible, making state easier to identify at a glance

## Test plan
- [x] Build succeeds (`zig build`)
- [x] Tests pass (`zig build test`)
- [x] Open the app, click the +- button → verify it appears "selected"
- [x] Click again → verify it returns to unselected state
- [x] Close diff sidebar via other means (e.g. `closeGitDiff`) → verify button resets to unselected


Made with [Cursor](https://cursor.com)