### PR TITLE
macos: add split-button toolbar item for opening in external editors

### DIFF
--- a/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsTahoeTerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TitlebarTabsTahoeTerminalWindow.swift
@@ -286,23 +286,24 @@ class TitlebarTabsTahoeTerminalWindow: TransparentTitlebarTerminalWindow, NSTool
     // MARK: NSToolbarDelegate
 
     func toolbarAllowedItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
-        var items: [NSToolbarItem.Identifier] = [
+        [
             .toggleSidebar,
             .sidebarTrackingSeparator,
             .title,
             .flexibleSpace,
             .space,
+            .openInEditor,
         ]
-        return items
     }
 
     func toolbarDefaultItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
-        return [
+        [
             .toggleSidebar,
             .sidebarTrackingSeparator,
             .flexibleSpace,
             .title,
             .flexibleSpace,
+            .openInEditor,
         ]
     }
 
@@ -335,9 +336,30 @@ class TitlebarTabsTahoeTerminalWindow: TransparentTitlebarTerminalWindow, NSTool
             item.label = "Toggle Sidebar"
             item.isNavigational = true
             return item
+        case .openInEditor:
+            return makeOpenInEditorItem()
         default:
             return NSToolbarItem(itemIdentifier: itemIdentifier)
         }
+    }
+
+    private func makeOpenInEditorItem() -> NSToolbarItem? {
+        let installed = ExternalEditor.installedEditors()
+        guard !installed.isEmpty else { return nil }
+
+        let controller = windowController as? TerminalController
+
+        let item = NSToolbarItem(itemIdentifier: .openInEditor)
+        item.label = "Open in Editor"
+        item.toolTip = "Open in Editor"
+
+        let segmented = EditorSplitButton.make(
+            editors: installed,
+            target: controller
+        )
+
+        item.view = segmented
+        return item
     }
 
     // MARK: SwiftUI

--- a/macos/Sources/Features/Worktrunk/WorktrunkPreferences.swift
+++ b/macos/Sources/Features/Worktrunk/WorktrunkPreferences.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 
 enum WorktrunkAgent: String, CaseIterable, Identifiable {
@@ -132,12 +133,147 @@ enum WorktrunkOpenBehavior: String, CaseIterable, Identifiable {
     }
 }
 
+enum ExternalEditorCategory: String {
+    case editors
+    case git
+    case finder
+}
+
+enum ExternalEditor: String, CaseIterable, Identifiable {
+    // Editors
+    case cursor
+    case vscode
+    case vscodium
+    case zed
+    case sublime
+    case nova
+    case textmate
+    case xcode
+    // JetBrains
+    case intellij
+    case webstorm
+    case pycharm
+    case goland
+    case rubymine
+    case clion
+    case rider
+    case phpstorm
+    case fleet
+    // Git clients
+    case tower
+    case fork
+    case gitkraken
+    case sourcetree
+    case githubDesktop
+    // Finder
+    case finder
+
+    var id: String { rawValue }
+
+    var category: ExternalEditorCategory {
+        switch self {
+        case .tower, .fork, .gitkraken, .sourcetree, .githubDesktop:
+            return .git
+        case .finder:
+            return .finder
+        default:
+            return .editors
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .cursor: return "Cursor"
+        case .vscode: return "VS Code"
+        case .vscodium: return "VSCodium"
+        case .zed: return "Zed"
+        case .sublime: return "Sublime Text"
+        case .nova: return "Nova"
+        case .xcode: return "Xcode"
+        case .textmate: return "TextMate"
+        case .intellij: return "IntelliJ IDEA"
+        case .webstorm: return "WebStorm"
+        case .pycharm: return "PyCharm"
+        case .goland: return "GoLand"
+        case .rubymine: return "RubyMine"
+        case .clion: return "CLion"
+        case .rider: return "Rider"
+        case .phpstorm: return "PhpStorm"
+        case .fleet: return "Fleet"
+        case .tower: return "Tower"
+        case .fork: return "Fork"
+        case .gitkraken: return "GitKraken"
+        case .sourcetree: return "Sourcetree"
+        case .githubDesktop: return "GitHub Desktop"
+        case .finder: return "Finder"
+        }
+    }
+
+    var bundleIdentifier: String {
+        switch self {
+        case .cursor: return "com.todesktop.230313mzl4w4u92"
+        case .vscode: return "com.microsoft.VSCode"
+        case .vscodium: return "com.vscodium"
+        case .zed: return "dev.zed.Zed"
+        case .sublime: return "com.sublimetext.4"
+        case .nova: return "com.panic.Nova"
+        case .xcode: return "com.apple.dt.Xcode"
+        case .textmate: return "com.macromates.TextMate"
+        case .intellij: return "com.jetbrains.intellij"
+        case .webstorm: return "com.jetbrains.WebStorm"
+        case .pycharm: return "com.jetbrains.pycharm"
+        case .goland: return "com.jetbrains.goland"
+        case .rubymine: return "com.jetbrains.rubymine"
+        case .clion: return "com.jetbrains.CLion"
+        case .rider: return "com.jetbrains.rider"
+        case .phpstorm: return "com.jetbrains.PhpStorm"
+        case .fleet: return "fleet.app"
+        case .tower: return "com.fournova.Tower3"
+        case .fork: return "com.DanPristupov.Fork"
+        case .gitkraken: return "com.axosoft.gitkraken"
+        case .sourcetree: return "com.torusknot.SourceTreeNotMAS"
+        case .githubDesktop: return "com.github.GitHubClient"
+        case .finder: return "com.apple.finder"
+        }
+    }
+
+    var appURL: URL? {
+        NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier)
+    }
+
+    var isInstalled: Bool {
+        appURL != nil
+    }
+
+    var appIcon: NSImage? {
+        guard let url = appURL else { return nil }
+        return NSWorkspace.shared.icon(forFile: url.path)
+    }
+
+    static func installedEditors() -> [ExternalEditor] {
+        allCases.filter { $0.isInstalled }
+    }
+
+    static func installedByCategory() -> [(category: ExternalEditorCategory, editors: [ExternalEditor])] {
+        let installed = installedEditors()
+        var result: [(category: ExternalEditorCategory, editors: [ExternalEditor])] = []
+        for cat in [ExternalEditorCategory.editors, .git, .finder] {
+            let group = installed.filter { $0.category == cat }
+            if !group.isEmpty {
+                result.append((category: cat, editors: group))
+            }
+        }
+        return result
+    }
+}
+
 enum WorktrunkPreferences {
     static let openBehaviorKey = "GhosttyWorktrunkOpenBehavior.v1"
     static let worktreeTabsKey = "GhosttyWorktreeTabs.v1"
     static let sidebarTabsKey = "GhostreeWorktrunkSidebarTabs.v1"
     static let defaultAgentKey = "GhosttyWorktrunkDefaultAgent.v1"
     static let githubIntegrationKey = "GhostreeGitHubIntegration.v1"
+    static let lastEditorKey = "GhostreeLastEditor.v1"
 
     static var worktreeTabsEnabled: Bool {
         UserDefaults.standard.bool(forKey: worktreeTabsKey)
@@ -156,5 +292,23 @@ enum WorktrunkPreferences {
             return true  // Default enabled
         }
         return UserDefaults.standard.bool(forKey: githubIntegrationKey)
+    }
+
+    static var lastEditor: ExternalEditor? {
+        get {
+            guard let raw = UserDefaults.standard.string(forKey: lastEditorKey) else { return nil }
+            return ExternalEditor(rawValue: raw)
+        }
+        set {
+            UserDefaults.standard.set(newValue?.rawValue, forKey: lastEditorKey)
+        }
+    }
+
+    static var preferredEditor: ExternalEditor? {
+        let installed = ExternalEditor.installedEditors()
+        if let last = lastEditor, installed.contains(last) {
+            return last
+        }
+        return installed.first
     }
 }


### PR DESCRIPTION
Adds a native split-button dropdown to the toolbar that opens the current working directory in an external editor. Clicking the button opens in the last-used editor; the dropdown arrow reveals a menu of all installed editors grouped by category (code editors, Git clients, Finder). The last-used editor is persisted across sessions.

Supported editors: Cursor, VS Code, VSCodium, Zed, Sublime Text, Nova, TextMate, Xcode, JetBrains IDEs (IntelliJ, WebStorm, PyCharm, GoLand, RubyMine, CLion, Rider, PHPStorm, Fleet), Tower, Fork, GitKraken, Sourcetree, GitHub Desktop, and Finder.