### PR TITLE
[macos] fix Tab navigation in new worktree sheet

### DIFF
--- a/macos/Sources/Features/Worktrunk/WorktrunkSidebarView.swift
+++ b/macos/Sources/Features/Worktrunk/WorktrunkSidebarView.swift
@@ -1116,6 +1116,7 @@ private struct CreateWorktreeSheet: View {
                 TextField("Branch", text: $branch)
                 TextField("Base (optional)", text: $base)
                 Toggle("Create branch", isOn: $createBranch)
+                    .focusable()
             }
 
             if let errorText, !errorText.isEmpty {


### PR DESCRIPTION
## Summary

- The "Create branch" Toggle in the new worktree sheet was unreachable via Tab key — focus would bounce between Branch and Base fields, skipping the checkbox entirely.
- Adds `.focusable()` to the Toggle so the full Tab cycle works: Branch → Base → Create branch → Cancel → Create.

## Changes

- Single `.focusable()` modifier on the Toggle in `CreateWorktreeSheet`. SwiftUI on macOS doesn't include Toggle in the keyboard focus cycle by default.

## Testing

- Open Ghostree → sidebar → click "New worktree…" → press Tab repeatedly.
- Before: focus cycles only between Branch and Base.
- After: focus traverses Branch → Base → Create branch toggle → Cancel → Create.

## Did this cause any problems?
Rollback/revert this commit and redeploy the service.

Made with [Cursor](https://cursor.com)