### PR TITLE
Fix diff panel transparency when toggled

### DIFF
--- a/macos/Sources/Features/GitDiff/GitDiffMainView.swift
+++ b/macos/Sources/Features/GitDiff/GitDiffMainView.swift
@@ -12,6 +12,7 @@ struct GitDiffMainView: View {
     var body: some View {
         content
             .frame(maxWidth: .greatestFiniteMagnitude, maxHeight: .greatestFiniteMagnitude, alignment: .topLeading)
+            .background(Color(nsColor: .controlBackgroundColor))
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary

- GitDiffMainView had no background color, so toggling the diff panel on showed a transparent area (revealing content beneath the window) instead of the expected "No diff" placeholder or diff content.
- Added `.background(Color(nsColor: .controlBackgroundColor))` to the view's outermost frame so it's always opaque.