### PR TITLE
Fix diff sidebar spinner pulsing on background refresh

### DIFF
--- a/macos/Sources/Features/GitDiff/GitDiffSidebarState.swift
+++ b/macos/Sources/Features/GitDiff/GitDiffSidebarState.swift
@@ -161,8 +161,11 @@ final class GitDiffSidebarState: ObservableObject {
 
         let start = DispatchTime.now().uptimeNanoseconds
 
-        isLoading = true
-        defer { isLoading = false }
+        // Only show the loading spinner for forced (user-initiated) refreshes,
+        // not for background poll/watch refreshes, to avoid visual pulsing.
+        let showLoading = force
+        if showLoading { isLoading = true }
+        defer { if showLoading { isLoading = false } }
 
         let root = await store.repoRoot(for: effectiveCwd.path)
         repoRoot = root


### PR DESCRIPTION
The 2-second poll loop and file watcher in `GitDiffSidebarState` were unconditionally setting `isLoading = true` on every `performRefresh` call. Since the sidebar view renders a `ProgressView` spinner whenever `isLoading` is true, this caused a visible pulse every few seconds. Now the loading indicator is only shown for forced/user-initiated refreshes (opening the panel, switching worktrees, stage/unstage), while background poll and watch refreshes update silently.