### PR TITLE
Restore sidebar grouping when sidebar tabs is enabled

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -23,23 +23,33 @@ final class WorktrunkSidebarState: ObservableObject {
         self.selection = selection
     }
 
-    func applyExpandedRepoIDs(_ next: Set<UUID>, listMode: WorktrunkSidebarListMode) {
+    func applyExpandedRepoIDs(
+        _ next: Set<UUID>,
+        listMode: WorktrunkSidebarListMode,
+        alwaysVisibleWorktreePaths: Set<String> = []
+    ) {
         guard next != expandedRepoIDs else { return }
         expandedRepoIDs = next
         pruneSelectionForVisibility(
             listMode: listMode,
             expandedRepoIDs: next,
-            expandedWorktreePaths: expandedWorktreePaths
+            expandedWorktreePaths: expandedWorktreePaths,
+            alwaysVisibleWorktreePaths: alwaysVisibleWorktreePaths
         )
     }
 
-    func applyExpandedWorktreePaths(_ next: Set<String>, listMode: WorktrunkSidebarListMode) {
+    func applyExpandedWorktreePaths(
+        _ next: Set<String>,
+        listMode: WorktrunkSidebarListMode,
+        alwaysVisibleWorktreePaths: Set<String> = []
+    ) {
         guard next != expandedWorktreePaths else { return }
         expandedWorktreePaths = next
         pruneSelectionForVisibility(
             listMode: listMode,
             expandedRepoIDs: expandedRepoIDs,
-            expandedWorktreePaths: next
+            expandedWorktreePaths: next,
+            alwaysVisibleWorktreePaths: alwaysVisibleWorktreePaths
         )
     }
 
@@ -115,18 +125,23 @@ final class WorktrunkSidebarState: ObservableObject {
     private func pruneSelectionForVisibility(
         listMode: WorktrunkSidebarListMode,
         expandedRepoIDs: Set<UUID>,
-        expandedWorktreePaths: Set<String>
+        expandedWorktreePaths: Set<String>,
+        alwaysVisibleWorktreePaths: Set<String>
     ) {
         guard let selection else { return }
         switch selection {
         case .repo:
             return
-        case .worktree(let repoID, _):
-            if listMode == .nestedByRepo, !expandedRepoIDs.contains(repoID) {
+        case .worktree(let repoID, let path):
+            if listMode == .nestedByRepo,
+               !expandedRepoIDs.contains(repoID),
+               !alwaysVisibleWorktreePaths.contains(path) {
                 self.selection = .repo(id: repoID)
             }
         case .session(_, let repoID, let worktreePath):
-            if listMode == .nestedByRepo, !expandedRepoIDs.contains(repoID) {
+            if listMode == .nestedByRepo,
+               !expandedRepoIDs.contains(repoID),
+               !alwaysVisibleWorktreePaths.contains(worktreePath) {
                 self.selection = .repo(id: repoID)
                 return
             }
@@ -1599,6 +1614,12 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
         (NSApp.delegate as? AppDelegate)?.worktrunkStore.sidebarListMode ?? .flatWorktrees
     }
 
+    private func currentWorktrunkAlwaysVisibleWorktreePaths() -> Set<String> {
+        guard WorktrunkPreferences.sidebarTabsEnabled else { return [] }
+        guard currentWorktrunkSidebarListMode() == .nestedByRepo else { return [] }
+        return Set(openTabsModel.tabs.compactMap(\.worktreeRootPath).map(Self.standardizedPath))
+    }
+
     private func applySyncedWorktrunkSidebarVisibility(_ visibility: NavigationSplitViewVisibility) {
         guard worktrunkSidebarState.columnVisibility != visibility else { return }
         worktrunkSidebarState.isApplyingRemoteUpdate = true
@@ -1618,7 +1639,11 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
             worktrunkSidebarSyncApplyingRemoteUpdate = false
             worktrunkSidebarState.isApplyingRemoteUpdate = false
         }
-        worktrunkSidebarState.applyExpandedRepoIDs(expandedRepoIDs, listMode: currentWorktrunkSidebarListMode())
+        worktrunkSidebarState.applyExpandedRepoIDs(
+            expandedRepoIDs,
+            listMode: currentWorktrunkSidebarListMode(),
+            alwaysVisibleWorktreePaths: currentWorktrunkAlwaysVisibleWorktreePaths()
+        )
     }
 
     private func applySyncedWorktrunkSidebarExpandedWorktreePaths(_ expandedWorktreePaths: Set<String>) {
@@ -1631,7 +1656,8 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
         }
         worktrunkSidebarState.applyExpandedWorktreePaths(
             expandedWorktreePaths,
-            listMode: currentWorktrunkSidebarListMode()
+            listMode: currentWorktrunkSidebarListMode(),
+            alwaysVisibleWorktreePaths: currentWorktrunkAlwaysVisibleWorktreePaths()
         )
     }
 

--- a/macos/Sources/Features/Worktrunk/WorktrunkSidebarView.swift
+++ b/macos/Sources/Features/Worktrunk/WorktrunkSidebarView.swift
@@ -189,7 +189,8 @@ struct WorktrunkSidebarView: View {
             if store.sidebarListMode == .nestedByRepo, sidebarState.expandedRepoIDs.isEmpty {
                 sidebarState.applyExpandedRepoIDs(
                     Set(store.sidebarSnapshot.repositories.map(\.id)),
-                    listMode: store.sidebarListMode
+                    listMode: store.sidebarListMode,
+                    alwaysVisibleWorktreePaths: currentAlwaysVisibleWorktreePaths()
                 )
             }
             clearSelectionIfMainInFlatMode()
@@ -311,6 +312,13 @@ struct WorktrunkSidebarView: View {
         return nil
     }
 
+    private func currentAlwaysVisibleWorktreePaths() -> Set<String> {
+        guard sidebarTabsEnabled else { return [] }
+        guard store.sidebarListMode == .nestedByRepo else { return [] }
+        let tabRoots = Set(openTabsModel.tabs.compactMap(\.worktreeRootPath).map(standardizedPath))
+        return tabRoots.intersection(store.sidebarWorktreePaths)
+    }
+
     @ViewBuilder
     private func sidebarTabsList(
         snapshot: WorktrunkStore.SidebarSnapshot,
@@ -327,6 +335,7 @@ struct WorktrunkSidebarView: View {
                 return (key, item.tab.windowNumber)
             }
         )
+        let alwaysVisibleWorktreePaths = Set(windowNumberByWorktreePath.keys)
         let moveBeforePreservingScroll: (Int, Int) -> Void = { moving, target in
             let scrollY = sidebarScrollPreserver.captureScrollY()
             moveNativeTabBefore(moving, target)
@@ -359,6 +368,7 @@ struct WorktrunkSidebarView: View {
                 openWorktreeAgent: openWorktreeAgent,
                 defaultAction: defaultAction,
                 availableAgents: availableAgents,
+                alwaysVisibleWorktreePaths: alwaysVisibleWorktreePaths,
                   focusNativeTab: focusNativeTab,
                   moveBefore: moveBeforePreservingScroll,
                   moveAfter: moveAfterPreservingScroll,
@@ -414,7 +424,11 @@ struct WorktrunkSidebarView: View {
                         } else {
                             next.remove(repo.id)
                         }
-                        sidebarState.applyExpandedRepoIDs(next, listMode: store.sidebarListMode)
+                        sidebarState.applyExpandedRepoIDs(
+                            next,
+                            listMode: store.sidebarListMode,
+                            alwaysVisibleWorktreePaths: excludingWorktreePaths
+                        )
                     }
                 )
             ) {
@@ -586,7 +600,11 @@ struct WorktrunkSidebarView: View {
                     } else {
                         next.remove(wt.path)
                     }
-                    sidebarState.applyExpandedWorktreePaths(next, listMode: store.sidebarListMode)
+                    sidebarState.applyExpandedWorktreePaths(
+                        next,
+                        listMode: store.sidebarListMode,
+                        alwaysVisibleWorktreePaths: currentAlwaysVisibleWorktreePaths()
+                    )
                 }
             )
         ) {
@@ -852,6 +870,7 @@ private struct WorktreeTabDisclosureGroup: View {
     let openWorktreeAgent: (String, WorktrunkAgent) -> Void
     let defaultAction: WorktrunkDefaultAction
     let availableAgents: [WorktrunkAgent]
+    let alwaysVisibleWorktreePaths: Set<String>
     let focusNativeTab: (Int) -> Void
     let moveBefore: (Int, Int) -> Void
     let moveAfter: (Int, Int) -> Void
@@ -868,7 +887,11 @@ private struct WorktreeTabDisclosureGroup: View {
                     } else {
                         next.remove(worktree.path)
                     }
-                    sidebarState.applyExpandedWorktreePaths(next, listMode: store.sidebarListMode)
+                    sidebarState.applyExpandedWorktreePaths(
+                        next,
+                        listMode: store.sidebarListMode,
+                        alwaysVisibleWorktreePaths: alwaysVisibleWorktreePaths
+                    )
                 }
             )
         ) {


### PR DESCRIPTION
## Summary
- always show the sidebar list grouping toggle (flat vs nested)
- remove forced flat-mode behavior when Sidebar tabs is enabled
- avoid duplicate worktree rows in nested mode by filtering out worktrees already shown in the tabs section

## Notes
- rebased branch onto latest remote main before these changes
- validated by launching with  (app started successfully)