### PR TITLE
Reduce sidebar spacing

### DIFF
--- a/macos/Sources/Features/Worktrunk/WorktrunkSidebarView.swift
+++ b/macos/Sources/Features/Worktrunk/WorktrunkSidebarView.swift
@@ -281,14 +281,16 @@ struct WorktrunkSidebarView: View {
         }()
         let topWorktreePaths = Set(worktreeTabs.compactMap(\.worktreeRootPath).map(standardizedPath))
         return List(selection: selection) {
-            if sidebarTabsEnabled {
-                sidebarTabsList(snapshot: snapshot, tabs: worktreeTabs)
-            }
+            Section {
+                if sidebarTabsEnabled {
+                    sidebarTabsList(snapshot: snapshot, tabs: worktreeTabs)
+                }
 
-            if store.sidebarListMode == .flatWorktrees {
-                flatWorktreeList(snapshot: snapshot, excludingWorktreePaths: topWorktreePaths)
-            } else {
-                nestedRepoList(snapshot: snapshot, excludingWorktreePaths: topWorktreePaths)
+                if store.sidebarListMode == .flatWorktrees {
+                    flatWorktreeList(snapshot: snapshot, excludingWorktreePaths: topWorktreePaths)
+                } else {
+                    nestedRepoList(snapshot: snapshot, excludingWorktreePaths: topWorktreePaths)
+                }
             }
         }
         .background(SidebarListScrollFinder(preserver: sidebarScrollPreserver))


### PR DESCRIPTION
## Summary
- Wraps the sidebar List content in a `Section` to eliminate extra vertical spacing between tab rows and worktree rows